### PR TITLE
chore: Update dependencies for `v0.0.5`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/careamics-{{ version }}.tar.gz
-  sha256: a1261fa0d552fd0d8fe0a956c64525957fd80fdd0906ef112028f9eeefaf030e
+  sha256: e1330aa84ecdf2319bad6694faaf8b5b9d7b2533a4c2a25000e1f760e60e03dd
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "careamics" %}
-{% set version = "0.0.4.2" %}
+{% set version = "0.0.5" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,17 +23,18 @@ requirements:
   run:
     - python >={{ python_min }}
     - numpy <2.0.0
-    - pytorch >=2.0.0
-    - torchvision
-    - tifffile
-    - psutil
-    - pydantic >=2.5,<2.9
-    - pytorch-lightning >=2.2.0
-    - pyyaml
-    - typer ==0.12.3
-    - scikit-image <=0.23.2
+    - pytorch >=2.0,<=2.5.1
+    - torchvision <=0.20.1
+    - bioimageio.core ==0.7
+    - tifffile <=2024.12.12
+    - pillow <=11.0.0
+    - psutil <=6.1
+    - pydantic >=2.5,<2.11
+    - pytorch-lightning >=2.2,<=2.4
+    - pyyaml <=6.0.2,!=6.0.0
+    - typer ==0.15.1
+    - scikit-image <=0.25.0
     - zarr <3.0.0
-    - bioimageio.core >=0.6.9
 
 test:
   imports:


### PR DESCRIPTION
Next time, I will push to the `bot` PR. For now, this one supersedes https://github.com/conda-forge/careamics-feedstock/pull/1, with the correct `version` and `hash`, but with the updated dependencies.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
